### PR TITLE
Exception coming in otherAllIndiaExam method

### DIFF
--- a/routes/freejobalert/route.js
+++ b/routes/freejobalert/route.js
@@ -211,7 +211,7 @@ async function otherAllIndiaExam(req, res, next) {
         })
         .then((data) => {
             res.status(200);
-            log.scuuess(data);
+            log.success(data);
             return res.results = data;
         })
     next();


### PR DESCRIPTION
(node:14108) UnhandledPromiseRejectionWarning: TypeError: log.scuuess is not a function
    at C:\xampp\htdocs\jobs\jobful-api\routes\freejobalert\route.js:214:17
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async otherAllIndiaExam (C:\xampp\htdocs\jobs\jobful-api\routes\freejobalert\route.js:206:5)
(node:14108) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)